### PR TITLE
default-enabled compression on CloudFront distro

### DIFF
--- a/cf.tf
+++ b/cf.tf
@@ -41,6 +41,7 @@ resource "aws_cloudfront_distribution" "web_distro" {
     min_ttl     = var.origin_min_ttl
     default_ttl = var.origin_default_ttl
     max_ttl     = var.origin_max_ttl
+    compress    = var.compress
   }
 
   dynamic "custom_error_response" {

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,7 @@ variable "restriction_locations" {
   default     = []
 }
 
+variable "compress" {
+  description = "Whether to compress files from the CF distro"
+  default     = true
+}


### PR DESCRIPTION
This should enable the types of compression that CloudFront supports for clients which support it, and improve page load times.

PS: I've never worked with Terraform before, so I'm not sure if this is right. Relevant doc: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution